### PR TITLE
Fix: llvm compiler error

### DIFF
--- a/include/spirit_po/exceptions.hpp
+++ b/include/spirit_po/exceptions.hpp
@@ -21,7 +21,7 @@ std::string iterator_context(Iterator & it, Iterator & end) {
     result = "Line " + std::to_string(line_no) + ":\n";
   }
 
-  uint count = 80;
+  unsigned int count = 80;
   while (it != end && count) {
     result += *it;
     ++it;


### PR DESCRIPTION
error: unknown type name 'uint'; did you mean 'int'?
  uint count = 80;