### PR TITLE
Add Support to use Catalog in a class withhout direct load of a PO file.

### DIFF
--- a/include/spirit_po/catalog.hpp
+++ b/include/spirit_po/catalog.hpp
@@ -245,6 +245,8 @@ public:
 #endif // SPIRIT_PO_DEBUG
   }
 
+  catalog() = default;
+
   // Upgrade an iterator pair to spirit::line_pos_iterators
   template <typename Iterator>
   static catalog from_iterators(Iterator & b, Iterator & e, warning_channel_type w = warning_channel_type()) {


### PR DESCRIPTION
By the default, if using a catalog object inside a class, it will issue that it can not find the default constructor: 

However, the only way to remove this error is by creating the catalog object inside class as followed in the constructor:
`Translation(void) : _cat(spirit_po::default_catalog::from_range(""))`

Of course, this constructor yields an exception since it is not a valid po source code. so it is not really possible to load a po file later in the code. especially not in the constructor.

`
Translation(void) {
std::ifstream ifs(fmt::format("{}.po", "en"));
std::string po_file{std::istreambuf_iterator<char>{ifs}, std::istreambuf_iterator<char>()};
auto catag = spirit_po::default_catalog::from_range(po_file);
this->_cat = catag;
}
`
This constructor does not compile. since ‘spirit_po::catalog<>::catalog() constructor is not found.

Other options is to provide a default string for the from_range functions of a valid minimum po data string
