### PR TITLE
Fix c++20

### DIFF
--- a/include/spirit_po/default_plural_forms_expressions.hpp
+++ b/include/spirit_po/default_plural_forms_expressions.hpp
@@ -23,8 +23,8 @@
 #include <algorithm>
 #include <vector>
 #include <boost/spirit/include/qi.hpp>
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/operator.hpp>
 #include <boost/fusion/include/adapt_struct.hpp>
 #include <boost/variant/variant.hpp>
 #include <boost/variant/recursive_wrapper.hpp>

--- a/include/spirit_po/default_plural_forms_expressions.hpp
+++ b/include/spirit_po/default_plural_forms_expressions.hpp
@@ -333,6 +333,9 @@ inline std::string debug_string(const instruction & i) {
  * Helper: Check if an expression obviously is zero-one valued
  */
 struct is_boolean : public boost::static_visitor<bool> {
+  // constructor is needed for boost::apply_visitor in C++17 (when using {} syntax) and C++20 (always)
+  is_boolean() = default;
+
   bool operator()(const and_op &) const { return true; }
   bool operator()(const or_op &) const { return true; }
   bool operator()(const not_op &) const { return true; }
@@ -353,6 +356,9 @@ struct is_boolean : public boost::static_visitor<bool> {
  * Visitor that maps expressions to instruction sequences
  */
 struct emitter : public boost::static_visitor<std::vector<instruction>> {
+  // constructor is needed for boost::apply_visitor in C++17 (when using {} syntax) and C++20 (always)
+  emitter() = default;
+
   std::vector<instruction> operator()(const constant & c) const {
     return std::vector<instruction>{instruction{c}};
   }

--- a/include/spirit_po/po_grammar.hpp
+++ b/include/spirit_po/po_grammar.hpp
@@ -11,8 +11,8 @@
 #endif
 
 #include <boost/spirit/include/qi.hpp>
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/operator.hpp>
 #include <boost/fusion/include/std_pair.hpp>
 #include <boost/fusion/include/define_struct.hpp>
 


### PR DESCRIPTION
The project currently fails to build under c++20. To fix it a constructor for any parent classes of boost::static_visitor needs to be added.  Additionally there were some depreciated headers used.
Related issue: #9 